### PR TITLE
Disable the interrupt before trying to lock.

### DIFF
--- a/src/mutex_irqsafe.rs
+++ b/src/mutex_irqsafe.rs
@@ -159,10 +159,11 @@ impl<T: ?Sized> MutexIrqSafe<T>
     /// ```
     pub fn lock(&self) -> MutexIrqSafeGuard<T>
     {
-        MutexIrqSafeGuard
-        {
-            held_irq: ManuallyDrop::new(hold_interrupts()),
-            guard: ManuallyDrop::new(self.lock.lock())
+        loop {
+            match self.try_lock() {
+                Some(guard) => return guard,
+                _ => {}
+            }
         }
     }
 

--- a/src/mutex_irqsafe.rs
+++ b/src/mutex_irqsafe.rs
@@ -181,12 +181,13 @@ impl<T: ?Sized> MutexIrqSafe<T>
     /// a guard within Some.
     pub fn try_lock(&self) -> Option<MutexIrqSafeGuard<T>>
     {
+        let held_irq = ManuallyDrop::new(hold_interrupts());
         match self.lock.try_lock() {
             None => None,
             success => {
                 Some(
                     MutexIrqSafeGuard {
-                        held_irq: ManuallyDrop::new(hold_interrupts()),
+                        held_irq,
                         guard: ManuallyDrop::new(success.unwrap()),
                     }
                 )


### PR DESCRIPTION
Disable the interrupt before trying to lock.

If the interrupt is not disabled, it might happen that the mutex is successfully locked, but right before the interrupt is disabled, an interrupt fires and the current thread is preempted. If this happens, other threads waiting for the lock will be starved.