### PR TITLE
Fix aarch64 interrupts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,3 @@ features = [ "alloc", "spin" ]
 
 [dependencies.owning_ref]
 git = "https://github.com/theseus-os/owning-ref-rs.git"
-
-[target.'cfg(target_arch = "arm")'.dependencies.cortex-m]
-features = ["inline-asm"]
-version = "0.7.2"

--- a/src/held_interrupts.rs
+++ b/src/held_interrupts.rs
@@ -35,7 +35,10 @@ impl Drop for HeldInterrupts {
 #[inline(always)]
 pub fn enable_interrupts() {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe { asm!("sti", options(nomem, nostack)); }
+    {
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        unsafe { asm!("sti", options(nomem, nostack)); }
+    }
 
     #[cfg(any(target_arch = "aarch64"))]
     {
@@ -53,7 +56,10 @@ pub fn enable_interrupts() {
 #[inline(always)]
 pub fn disable_interrupts() {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    unsafe { asm!("cli", options(nomem, nostack)); }
+    {
+        unsafe { asm!("cli", options(nomem, nostack)) };
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    }
 
     #[cfg(any(target_arch = "aarch64"))]
     {

--- a/src/held_interrupts.rs
+++ b/src/held_interrupts.rs
@@ -1,9 +1,9 @@
 // Inspired by Tifflin OS
 
-#[cfg(any(target_arch="arm"))]
+#[cfg(any(target_arch = "arm"))]
 extern crate cortex_m;
 
-#[cfg(any(target_arch="arm"))]
+#[cfg(any(target_arch = "arm"))]
 use self::cortex_m::{interrupt, register};
 
 use core::arch::asm;
@@ -12,73 +12,77 @@ use core::arch::asm;
 #[derive(Default)]
 pub struct HeldInterrupts(bool);
 
-/// Prevent interrupts from firing until the return value is dropped (goes out of scope). 
-/// After it is dropped, the interrupts are returned to their prior state, not blindly re-enabled. 
+/// Prevent interrupts from firing until the return value is dropped (goes out of scope).
+/// After it is dropped, the interrupts are returned to their prior state, not blindly re-enabled.
 pub fn hold_interrupts() -> HeldInterrupts {
     let enabled = interrupts_enabled();
-	let retval = HeldInterrupts(enabled);
+    let retval = HeldInterrupts(enabled);
     disable_interrupts();
     // trace!("hold_interrupts(): disabled interrupts, were {}", enabled);
     retval
 }
 
-
 impl Drop for HeldInterrupts {
-	fn drop(&mut self) {
+    fn drop(&mut self) {
         // trace!("hold_interrupts(): enabling interrupts? {}", self.0);
-		if self.0 {
-			enable_interrupts();
-		}
-	}
+        if self.0 {
+            enable_interrupts();
+        }
+    }
 }
-
-
-
 
 // Rust wrappers around the x86-family of interrupt-related instructions.
 #[inline(always)]
 pub fn enable_interrupts() {
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     unsafe { asm!("sti", options(nomem, nostack)); }
 
-    #[cfg(any(target_arch="aarch64"))]
-    unsafe { asm!("cpsie i", options(nomem, nostack)); }
+    #[cfg(any(target_arch = "aarch64"))]
+    {
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        unsafe {
+            asm!("msr daifclr, #3", options(nomem, nostack, preserves_flags));
+        };
+    }
 
-    #[cfg(any(target_arch="arm"))]
+    #[cfg(any(target_arch = "arm"))]
     unsafe { interrupt::enable(); }
 }
 
-
 #[inline(always)]
 pub fn disable_interrupts() {
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     unsafe { asm!("cli", options(nomem, nostack)); }
 
-    #[cfg(any(target_arch="aarch64"))]
-    unsafe { asm!("cpsid i", options(nomem, nostack)); }
+    #[cfg(any(target_arch = "aarch64"))]
+    {
+        unsafe {
+            asm!("msr daifset, #3", options(nomem, nostack, preserves_flags));
+        };
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    }
 
-    #[cfg(any(target_arch="arm"))]
+    #[cfg(any(target_arch = "arm"))]
     interrupt::disable();
 }
 
-
 #[inline(always)]
 pub fn interrupts_enabled() -> bool {
-    #[cfg(any(target_arch="x86", target_arch="x86_64"))]
-    unsafe { 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    unsafe {
         // we only need the lower 16 bits of the eflags/rflags register
         let flags: usize;
         asm!("pushfq; pop {}", out(reg) flags, options(nomem, preserves_flags));
-		(flags & 0x0200) != 0
-     }
-
-    #[cfg(any(target_arch="aarch64"))]
-    unsafe {
-        let primask: usize;  
-        asm!("mrs {}, PRIMASK", out(reg) primask, options(nomem, preserves_flags));
-        primask == 0
+        (flags & 0x0200) != 0
     }
 
-    #[cfg(any(target_arch="arm"))]
+    #[cfg(any(target_arch = "aarch64"))]
+    unsafe {
+        let daif: usize;
+        asm!("mrs {}, daif", out(reg) daif, options(nomem, preserves_flags));
+        daif >> 6 & 0x3 == 0
+    }
+
+    #[cfg(any(target_arch = "arm"))]
     register::primask::read().is_active()
 }

--- a/src/held_interrupts.rs
+++ b/src/held_interrupts.rs
@@ -41,6 +41,7 @@ pub fn enable_interrupts() {
     {
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
         unsafe {
+            // Clear the i and f bits.
             asm!("msr daifclr, #3", options(nomem, nostack, preserves_flags));
         };
     }
@@ -57,6 +58,7 @@ pub fn disable_interrupts() {
     #[cfg(any(target_arch = "aarch64"))]
     {
         unsafe {
+            // Set the i and f bits.
             asm!("msr daifset, #3", options(nomem, nostack, preserves_flags));
         };
         core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
@@ -80,6 +82,8 @@ pub fn interrupts_enabled() -> bool {
     unsafe {
         let daif: usize;
         asm!("mrs {}, daif", out(reg) daif, options(nomem, preserves_flags));
+        // The flags are stored in bits 7-10. We only care about i and f,
+        // stored in bits 7 and 8.
         daif >> 6 & 0x3 == 0
     }
 


### PR DESCRIPTION
Previously, `irq_safety` wouldn't compile on aarch64 because `cpsid` and `cpsie` aren't valid mnemonics.

The implementation is "based on" [Linux](https://elixir.bootlin.com/linux/latest/source/arch/arm64/include/asm/irqflags.h#L96) and [Android](https://android.googlesource.com/kernel/msm/+/android-7.1.0_r0.2/arch/arm64/include/asm/irqflags.h).

I've tested the following snippet of code in a freestanding aarch64 binary:
```rust
disable_interrupts();
assert!(!interrupts_enabled());
enable_interrupts();
assert!(interrupts_enabled());
enable_interrupts();
assert!(interrupts_enabled());
disable_interrupts();
assert!(!interrupts_enabled());
```
I haven't been able to test if interrupts are actually disabled, just that the corresponding registers have the correct values, but I am using the same instructions as Linux.

The [specification](https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/DAIF--Interrupt-Mask-Bits?lang=en#fieldset_0-5_0) explains why the bit shift is required when checking if interrupts are enabled. The bit shift is intentionally omitted when enabling and disabling because `clr` and `set` magically do it for you.

Like Linux, I've ignored the D and A bit. I'm pretty sure this is ok as D is for breakpoints and A is for SErrors, which I believe are hardware memory errors.

There are also a couple of formatting changes; I wouldn't say they are particularly controversial.

Signed-off-by: Klim Tsoutsman <klim@tsoutsman.com>