### PR TITLE
Unimplement `Send` for `HeldInterrupts`

### DIFF
--- a/src/held_interrupts.rs
+++ b/src/held_interrupts.rs
@@ -9,6 +9,8 @@ use core::{
 #[derive(Default)]
 pub struct HeldInterrupts(bool);
 
+impl !Send for HeldInterrupts {}
+
 /// Prevent interrupts from firing until the return value is dropped (goes out of scope).
 /// After it is dropped, the interrupts are returned to their prior state, not blindly re-enabled.
 pub fn hold_interrupts() -> HeldInterrupts {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //! Both of these types implement the [`stable_deref_trait::StableDeref`] trait,
 //! allowing them to be used with crates like `owning_ref`.
 
+#![feature(negative_impls)]
+
 #![no_std]
 
 extern crate spin;


### PR DESCRIPTION
Sending a `HeldInterrupts` to another core will result in interrupts never being disabled on the current core, and potentially being disabled preemptively on the other core.