### PR TITLE
Remove usage of `owning_ref` and `stable_deref_trait`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,3 @@ version = "0.9.0"
 default-features = false
 features = ["mutex", "spin_mutex", "rwlock", "once", "barrier"]
 
-[dependencies.stable_deref_trait]
-git = "https://github.com/theseus-os/stable_deref_trait.git"
-branch = "spin"
-default-features = false
-features = [ "alloc", "spin" ]
-
-[dependencies.owning_ref]
-git = "https://github.com/theseus-os/owning-ref-rs.git"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,12 @@
 //! * [ MutexIrqSafe`] and [`RwLockIrqSafe`]: spinlock wrappers that use [`spin::Mutex`]
 //!   and [`spin::RwLock`] internally to auto-disable interrupts for the duration of 
 //!   the lock being held.
-//! 
-//! Both of these types implement the [`stable_deref_trait::StableDeref`] trait,
-//! allowing them to be used with crates like `owning_ref`.
 
 #![feature(negative_impls)]
 
 #![no_std]
 
 extern crate spin;
-extern crate owning_ref;
-extern crate stable_deref_trait;
 
 pub use mutex_irqsafe::*;
 pub use rwlock_irqsafe::*;

--- a/src/mutex_irqsafe.rs
+++ b/src/mutex_irqsafe.rs
@@ -1,8 +1,6 @@
 use core::{fmt, ops::{Deref, DerefMut}};
 use spin::{Mutex, MutexGuard};
 use crate::held_interrupts::{HeldInterrupts, hold_interrupts};
-use stable_deref_trait::StableDeref;
-use owning_ref::{OwningRef, OwningRefMut};
 
 /// This type provides interrupt-safe MUTual EXclusion based on [spin::Mutex].
 ///
@@ -227,11 +225,3 @@ impl<'a, T: ?Sized> DerefMut for MutexIrqSafeGuard<'a, T> {
         &mut *(self.guard)
     }
 }
-
-// Implement the StableDeref trait for MutexIrqSafe guards, just like it's implemented for Mutex guards
-unsafe impl<'a, T: ?Sized> StableDeref for MutexIrqSafeGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `MutexIrqSafeGuard` as the owner.
-pub type MutexIrqSafeGuardRef<'a, T, U = T> = OwningRef<MutexIrqSafeGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `MutexIrqSafeGuard` as the owner.
-pub type MutexIrqSafeGuardRefMut<'a, T, U = T> = OwningRefMut<MutexIrqSafeGuard<'a, T>, U>;

--- a/src/rwlock_irqsafe.rs
+++ b/src/rwlock_irqsafe.rs
@@ -1,8 +1,6 @@
 use core::{fmt, ops::{Deref, DerefMut}};
 use spin::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::held_interrupts::{HeldInterrupts, hold_interrupts};
-use stable_deref_trait::StableDeref;
-use owning_ref::{OwningRef, OwningRefMut};
 
 /// A simple wrapper around a `RwLock` whose guards disable interrupts properly 
 pub struct RwLockIrqSafe<T: ?Sized> {
@@ -282,12 +280,3 @@ impl<'rwlock, T: ?Sized> DerefMut for RwLockIrqSafeWriteGuard<'rwlock, T> {
         &mut *(self.guard)
     }
 }
-
-// Implement the StableDeref trait for RwLockIrqSafe guards, just like it's implemented for RwLock guards
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockIrqSafeReadGuard<'a, T> {}
-unsafe impl<'a, T: ?Sized> StableDeref for RwLockIrqSafeWriteGuard<'a, T> {}
-
-/// Typedef of a owning reference that uses a `RwLockIrqSafeReadGuard` as the owner.
-pub type RwLockIrqSafeReadGuardRef<'a, T, U = T> = OwningRef<RwLockIrqSafeReadGuard<'a, T>, U>;
-/// Typedef of a mutable owning reference that uses a `RwLockIrqSafeWriteGuard` as the owner.
-pub type RwLockIrqSafeWriteGuardRefMut<'a, T, U = T> = OwningRefMut<RwLockIrqSafeWriteGuard<'a, T>, U>;


### PR DESCRIPTION
* `owning_ref` has been shown to be unsound.
* Thus, Theseus no longer uses `owning_ref` at all, so this crate does not need to implement it.