### PR TITLE
aarch64: allow disabling and enabling FIQs distinctively

### DIFF
--- a/src/held_interrupts.rs
+++ b/src/held_interrupts.rs
@@ -116,7 +116,7 @@ pub fn interrupts_enabled() -> bool {
     unsafe {
         let daif: usize;
         asm!("mrs {}, daif", out(reg) daif, options(nomem, nostack, preserves_flags));
-        // The flags are stored in bits 7-10. We only care about i, stored in bit 8.
+        // The flags are stored in bits 6, 7, 8, 9. We only care about i, stored in bit 7.
         (daif & (1 << 7)) == 0
     }
 


### PR DESCRIPTION
Previously, FIQs and IRQs were both disabled/enabled by `enable/disable_interrupts`.
With this merged, only IRQs are affected. There are two new functions for FIQs:
`enable_fast_interrupts` & `disable_fast_interrupts`.